### PR TITLE
update build workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,10 +3,19 @@
 name: Build
 
 on:
-  schedule:
-    - cron: '0 0 1 * *' # at 00:00 on the first day of the month
+
+  push:
+    branches:
+      - master
+
+  #schedule:
+  #  - cron: '0 0 1 * *' # at 00:00 on the first day of the month
 
   workflow_dispatch:
+
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,58 +1,68 @@
-# This is a basic workflow to help you get started with Actions
+# Build and store HackyPi artifacts
 
 name: Build
 
-# Controls when the workflow will run
 on:
   schedule:
     - cron: '0 0 1 * *' # at 00:00 on the first day of the month
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Cache Bitbake Output
         id: cache-bitbake
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: build/downloads
           key: ${{ runner.os }}-bitbake-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-bitbake-
 
-      - name: Bitbake
+      - name: Setup Environment
         shell: bash
         run: |
           bash setup.sh
-          source poky/oe-init-build-env
+
+      - name: Bitbake HackyPi Image - Raspberry Pi 4
+        shell: bash
+        run: |
+          source poky/oe-init-build-env &>/dev/null
           bitbake hackypi-image
+
+      - name: Bitbake HackyPi Image - Raspberry Pi 3
+        shell: bash
+        run: |
+          source poky/oe-init-build-env &>/dev/null
           MACHINE=raspberrypi3 bitbake hackypi-image
+
+      - name: Bitbake HackyPi Challenges
+        shell: bash
+        run: |
+          source poky/oe-init-build-env &>/dev/null
           bitbake chatty-charly
           bitbake relaxed-rachel
 
-      - name: Remove Old Artifacts
-        uses: c-hive/gha-remove-artifacts@v1
-        with:
-          age: '1 day'
-
       - name: Archive New Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.0
         with:
           name: security-challenge-package
           path: |
             build/tmp/deploy/images/raspberrypi4/hackypi-image-raspberrypi4-*.rpi-sdimg
             build/tmp/deploy/images/raspberrypi3/hackypi-image-raspberrypi3-*.rpi-sdimg
-            build/tmp/deploy/ipk/cortexa7t2hf-neon-vfpv4/chatty-charly_*.ipk
-            build/tmp/deploy/ipk/cortexa7t2hf-neon-vfpv4/relaxed-rachel_*.ipk
+            build/tmp/deploy/ipk/cortexa7t2hf-neon-vfpv4/*.ipk
+            !build/tmp/deploy/ipk/cortexa7t2hf-neon-vfpv4/*-dbg*.ipk
+            !build/tmp/deploy/ipk/cortexa7t2hf-neon-vfpv4/*-src*.ipk
+            !build/tmp/deploy/ipk/cortexa7t2hf-neon-vfpv4/*-doc*.ipk
+            !build/tmp/deploy/ipk/cortexa7t2hf-neon-vfpv4/*-dev*.ipk
+            !build/tmp/deploy/ipk/cortexa7t2hf-neon-vfpv4/*-ptest*.ipk
+            !build/tmp/deploy/ipk/cortexa7t2hf-neon-vfpv4/*-syslog*.ipk
+            !build/tmp/deploy/ipk/cortexa7t2hf-neon-vfpv4/*-staticdev*.ipk

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@
 PROJECT_PATH="$PWD"
 
 # install dependencies
-sudo apt install -y bc build-essential chrpath cpio diffstat gawk git python texinfo wget python3-distutils
+sudo apt install -y bc build-essential chrpath cpio diffstat gawk git python texinfo wget python3-distutils chrpath diffstat
 
 # checkout meta-layers
 git clone --depth 1 git://git.yoctoproject.org/poky.git --branch dunfell --single-branch

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@
 PROJECT_PATH="$PWD"
 
 # install dependencies
-sudo apt install -y bc build-essential chrpath cpio diffstat gawk git python texinfo wget python3-distutils chrpath diffstat
+sudo apt install -y bc build-essential chrpath cpio diffstat gawk git texinfo wget python3-distutils chrpath diffstat
 
 # checkout meta-layers
 git clone --depth 1 git://git.yoctoproject.org/poky.git --branch dunfell --single-branch


### PR DESCRIPTION
Enhancement #2 

- use new runner ubuntu-22.04 
- split up build steps
- update actions
- remove deprecated "remove-artifacts" action
- store all release ipk packages as build artifacts (no dbg, no dev, etc.)
- remove unnecessary comments in workflow file
- update triggers